### PR TITLE
Stop using reserved JavaScript keyword `interface`

### DIFF
--- a/lib/moie.js
+++ b/lib/moie.js
@@ -117,10 +117,10 @@ export default {
             util.startMoieServer(() => this.connect())
             this.triedAsSubprocess = true
           } else {
-            const interface = atom.config.get('MoPE.interface')
+            const mopeInterface = atom.config.get('MoPE.interface')
             const port = atom.config.get('MoPE.port')
             atom.notifications.addError(
-              `Couldn't connect Mo|E to ${interface}:${port}!`,
+              `Couldn't connect Mo|E to ${mopeInterface}:${port}!`,
               {dismissable: false, detail: msg}
             )
             this.statusView.error("disconnected")

--- a/lib/util.js
+++ b/lib/util.js
@@ -24,7 +24,7 @@ export default {
   startMoieServer(afterStart) {
     const self=this
     const execPath = atom.config.get('MoPE.mopeExec')
-    const interface = atom.config.get('MoPE.interface')
+    const mopeInterface = atom.config.get('MoPE.interface')
     const port = atom.config.get('MoPE.port')
     const command = atom.config.get('MoPE.javaExec')
     const args = ['-jar', execPath]


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!